### PR TITLE
update environment for pinned holoviz tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
+        os: ['macos-latest']
         python-version: [3.7]
     steps:
       - uses: actions/checkout@v2

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: omnisci
 
 channels:
+  - quansight/label/omnisci
   - conda-forge
 
 dependencies:
@@ -8,8 +9,8 @@ dependencies:
   - bokeh
   - geoviews
   - graphviz
-  - hvplot
-  - ibis-framework
+  - ibis-vega-transform
+  - intake
   - jaeger
   - jupyterlab>=2
   - llvmlite>=0.29
@@ -19,14 +20,20 @@ dependencies:
   - numba
   - omnisci-pytools
   - pip
+  - pydot
   - pymapd
   - pytest
   - python=3.7
+  - python-graphviz
   - rbc
   - six
   - tblib
   - thriftpy2
   - tornado
 
+  - quansight/label/omnisci::holoviews
+  - quansight/label/omnisci::hvplot
+  - quansight/label/omnisci::ibis-framework
+
   - pip:
-    - ibis-vega-transform
+    - intake-omnisci


### PR DESCRIPTION
* use holoviews, hvplot, and ibis-framework from `qoansight/label/omnisci` channel
* add several related packages

Note: 
- This works for `notebooks/workshop/Connecting_Holoviz...*.ipynb` and `notebooks/workshop/Interactive_Computing....*ipynb` (the holoviews and basic demo notebooks, respectively)
- This does not work for `notebooks/workshop/Altair...ipynb`
  - Throws `Javascript Error: Unexpected token < in JSON at position 0`
- This does not work for `notebooks/workshop/User_Defined_Algorithms....ipynb`
  - Requires `rbc>0.4`, this provides `0.2.2`