### PR TITLE
Add ibis import compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: [3.7]
     steps:
       - uses: actions/checkout@v2
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
            activate-environment: omnisci
            environment-file: environment.yml

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: omnisci
 
 channels:
+  - quansight/label/omnisci
   - conda-forge
 
 dependencies:
@@ -8,25 +9,25 @@ dependencies:
   - bokeh
   - geoviews
   - graphviz
-  - hvplot
-  - ibis-framework
+  - quansight/label/omnisci::hvplot
+  - quansight/label/omnisci::holoviews
+  - ibis-framework >=1.4
   - jaeger
-  - jupyterlab>=2
-  - llvmlite>=0.29
+  - jupyterlab >=2
+  - llvmlite >=0.29
   - netifaces
-  - nodejs>=12
+  - nodejs >=12
   - notebook
   - numba
   - omnisci-pytools
   - pip
   - pymapd
   - pytest
-  - python=3.7
-  - rbc
+  - python 3.7.*
+  - rbc >=0.4
   - six
   - tblib
   - thriftpy2
   - tornado
-
   - pip:
     - ibis-vega-transform

--- a/notebooks/02_Querying_Data.ipynb
+++ b/notebooks/02_Querying_Data.ipynb
@@ -183,7 +183,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ibis\n",
+    "import warnings\n",
+    "\n",
+    "from ibis.backends import omniscidb as ibis_omniscidb\n",
+    "    \n",
     "# set up the credentials to the OmniSci db inside of docker\n",
     "creds = {\n",
     "    'user': 'admin',\n",
@@ -192,8 +195,13 @@
     "    'port': 6274,\n",
     "    'dbname': 'omnisci'\n",
     "}\n",
-    "omnisci_client = ibis.omniscidb.connect(user=creds['user'], password=creds['password'],\n",
-    "                                  host=creds['host'], port=creds['port'], database=creds['dbname'])"
+    "omnisci_client = ibis_omniscidb.connect(\n",
+    "    user=creds['user'],\n",
+    "    password=creds['password'],\n",
+    "    host=creds['host'],\n",
+    "    port=creds['port'],\n",
+    "    database=creds['dbname']\n",
+    ")"
    ]
   },
   {

--- a/notebooks/04_Advanced-Using_UDFs_and_UDTFs.ipynb
+++ b/notebooks/04_Advanced-Using_UDFs_and_UDTFs.ipynb
@@ -75,9 +75,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ibis\n",
-    "ibis_con = ibis.omniscidb.connect(user=omni.user, password=omni.password,\n",
-    "                                  host=omni.host, port=omni.port, database=omni.dbname)"
+    "from ibis.backends import omniscidb as ibis_omniscidb\n",
+    "    \n",
+    "ibis_con = ibis_omniscidb.connect(\n",
+    "    user=omni.user,\n",
+    "    password=omni.password,\n",
+    "    host=omni.host,\n",
+    "    port=omni.port,\n",
+    "    database=omni.dbname\n",
+    ")"
    ]
   },
   {

--- a/notebooks/additional_examples/A01_Getting_Started_OmniSciDB_and_Ibis.ipynb
+++ b/notebooks/additional_examples/A01_Getting_Started_OmniSciDB_and_Ibis.ipynb
@@ -76,7 +76,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ibis\n",
+    "from ibis.backends import omniscidb as ibis_omniscidb\n",
+    "\n",
     "# set up the credentials to the OmniSci db inside of docker\n",
     "creds = {\n",
     "    'user': 'admin',\n",
@@ -86,8 +87,13 @@
     "    'dbname': 'omnisci'\n",
     "}\n",
     "# connect to the database using Ibis\n",
-    "omnisci_client = ibis.omniscidb.connect(user=creds['user'], password=creds['password'],\n",
-    "                                  host=creds['host'], port=creds['port'], database=creds['dbname'])"
+    "omnisci_client = ibis_omniscidb.connect(\n",
+    "    user=creds['user'],\n",
+    "    password=creds['password'],\n",
+    "    host=creds['host'],\n",
+    "    port=creds['port'],\n",
+    "    database=creds['dbname']\n",
+    ")"
    ]
   },
   {

--- a/notebooks/additional_examples/A02_Omnisci_Runtime_UDF.ipynb
+++ b/notebooks/additional_examples/A02_Omnisci_Runtime_UDF.ipynb
@@ -43,8 +43,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ibis\n",
-    "ibis_con = ibis.omniscidb.connect(user=omni.user, password=omni.password,\n",
+    "from ibis.backends import omniscidb as ibis_omniscidb\n",
+    "\n",
+    "ibis_con = ibis_omniscidb.connect(user=omni.user, password=omni.password,\n",
     "                                  host=omni.host, port=omni.port, database=omni.dbname)"
    ]
   },

--- a/notebooks/additional_examples/A03_Ibis_Altair_Extraction.ipynb
+++ b/notebooks/additional_examples/A03_Ibis_Altair_Extraction.ipynb
@@ -16,9 +16,9 @@
    "outputs": [],
    "source": [
     "import altair as alt\n",
-    "import ibis.omniscidb\n",
     "import IPython.display\n",
-    "import ibis_vega_transform"
+    "import ibis_vega_transform\n",
+    "from ibis.backends import omniscidb as ibis_omniscidb"
    ]
   },
   {
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "conn = ibis.omniscidb.connect(\n",
+    "conn = ibis_omniscidb.connect(\n",
     "    host='metis.mapd.com', user='demouser', password='HyperInteractive',\n",
     "    port=443, database='mapd', protocol= 'https'\n",
     ")\n",

--- a/notebooks/additional_examples/A04_Replicate_MapD_Example.ipynb
+++ b/notebooks/additional_examples/A04_Replicate_MapD_Example.ipynb
@@ -19,9 +19,9 @@
    "source": [
     "import altair as alt\n",
     "import ibis_vega_transform\n",
-    "import ibis.omniscidb\n",
+    "from ibis.backends import omniscidb as ibis_omniscidb\n",
     "\n",
-    "conn = ibis.omniscidb.connect(\n",
+    "conn = ibis_omniscidb.connect(\n",
     "    host='metis.mapd.com', user='demouser', password='HyperInteractive',\n",
     "    port=443, database='mapd', protocol='https'\n",
     ")"

--- a/notebooks/additional_examples/A05_Replicate_Vega_at_a_Glance_Example.ipynb
+++ b/notebooks/additional_examples/A05_Replicate_Vega_at_a_Glance_Example.ipynb
@@ -17,9 +17,9 @@
    "source": [
     "import altair as alt\n",
     "import ibis_vega_transform\n",
-    "import ibis\n",
+    "from ibis.backends import omniscidb as ibis_omniscidb\n",
     "\n",
-    "conn = ibis.omniscidb.connect(\n",
+    "conn = ibis_omniscidb.connect(\n",
     "    host='metis.mapd.com', user='demouser', password='HyperInteractive',\n",
     "    port=443, database='mapd', protocol= 'https'\n",
     ")\n",

--- a/notebooks/additional_examples/A06_Replicate_Interactive_Slider_Example.ipynb
+++ b/notebooks/additional_examples/A06_Replicate_Interactive_Slider_Example.ipynb
@@ -86,9 +86,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ibis\n",
+    "from ibis.backends import sqlite as ibis_sqlite\n",
     "\n",
-    "connection = ibis.sqlite.connect(dbfile)\n",
+    "connection = ibis_sqlite.connect(dbfile)\n",
     "connection.list_tables()"
    ]
   },

--- a/notebooks/workshop/Altair_Ibis_Vega_for_Interactive_Exploration.ipynb
+++ b/notebooks/workshop/Altair_Ibis_Vega_for_Interactive_Exploration.ipynb
@@ -34,10 +34,9 @@
    "source": [
     "import altair as alt\n",
     "import ibis_vega_transform\n",
-    "import ibis.omniscidb\n",
+    "from ibis.backends import omniscidb as ibis_omniscidb\n",
     "\n",
-    "\n",
-    "conn = ibis.omniscidb.connect(\n",
+    "conn = ibis_omniscidb.connect(\n",
     "    host='metis.mapd.com', user='demouser', password='HyperInteractive',\n",
     "    port=443, database='mapd', protocol= 'https'\n",
     ")"

--- a/notebooks/workshop/Connecting_Holoviz_Visualization_Ecosystem_to_OmniSci_part_1.ipynb
+++ b/notebooks/workshop/Connecting_Holoviz_Visualization_Ecosystem_to_OmniSci_part_1.ipynb
@@ -57,6 +57,9 @@
     "from holoviews import opts\n",
     "import numpy as np\n",
     "import hvplot.ibis\n",
+    "\n",
+    "from ibis.backends import omniscidb as ibis_omniscidb\n",
+    "\n",
     "hv.extension('bokeh')"
    ]
   },
@@ -73,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client = ibis.omniscidb.connect(\n",
+    "client = ibis_omniscidb.connect(\n",
     "    user=\"mapd\", \n",
     "    password=\"HyperInteractive\", \n",
     "    host=\"metis.mapd.com\", \n",

--- a/notebooks/workshop/Connecting_Holoviz_Visualization_Ecosystem_to_OmniSci_part_2.ipynb
+++ b/notebooks/workshop/Connecting_Holoviz_Visualization_Ecosystem_to_OmniSci_part_2.ipynb
@@ -38,9 +38,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ibis\n",
+    "from ibis.backends import omniscidb as ibis_omniscidb\n",
     "\n",
-    "conn = ibis.omniscidb.connect(\n",
+    "conn = omniscidb.connect(\n",
     "    host='metis.mapd.com', user='demouser', password='HyperInteractive',\n",
     "    port=443, database='mapd', protocol='https'\n",
     ")"

--- a/notebooks/workshop/Interactive_Computing_in_Jupyter_and_Python_part_1.ipynb
+++ b/notebooks/workshop/Interactive_Computing_in_Jupyter_and_Python_part_1.ipynb
@@ -105,9 +105,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ibis\n",
+    "from ibis.backends import omniscidb as ibis_omniscidb\n",
     "\n",
-    "omnisci_client = ibis.omniscidb.connect(\n",
+    "omnisci_client = ibis_omniscidb.connect(\n",
     "    user='demouser', \n",
     "    password='HyperInteractive',\n",
     "    host='ships-demo-local.mapd.com', \n",


### PR DESCRIPTION
The new ibis version (not released yet) changes the package structure, where all the backends are grouped into the `ibis.backends package`.

This PR changes the notebooks to work with the new ibis package structure. 