### PR TITLE
Fix omnisci.conf reference

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       - 6274:6274
       - 6278:6278
     volumes:
-      - ./omniscidb.conf:/omnisci-storage/omnisci.conf
+      - ./omnisci.conf:/omnisci-storage/omnisci.conf

--- a/notebooks/workshop/User_Defined_Algorithms_on_Big_Data.ipynb
+++ b/notebooks/workshop/User_Defined_Algorithms_on_Big_Data.ipynb
@@ -482,10 +482,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
     "User defined Aggregated function"
    ]


### PR DESCRIPTION
This PR fix the name of the omnisci config file used by docker-compose. also it changes a notebook cell from code type to markdown type.