### PR TITLE
Fix conda packaging build script

### DIFF
--- a/.github/workflows/conda-build.yaml
+++ b/.github/workflows/conda-build.yaml
@@ -35,7 +35,7 @@ jobs:
 
     - name: run conda build
       shell: bash -l {0}
-      run: conda-build conda -c quansight/label/omnisci
+      run: conda-build conda
 
     - name: release to the quansight conda channel
       shell: bash -l {0}

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -3,7 +3,7 @@
 TARGET_DIR=${PREFIX}/opt/omnisci-examples/
 mkdir -p ${TARGET_DIR}
 
-# remore .git if exists
-rm -rf .git
-
 cp -R . ${TARGET_DIR}
+
+# remore .git if exists
+rm -rf ${TARGET_DIR}/.git


### PR DESCRIPTION
This PR fix an issue with the conda package build script. remove .git inside the package working directory is not allowed. 