### PR TITLE
Fix gh actions for conda build

### DIFF
--- a/.github/workflows/conda-build.yaml
+++ b/.github/workflows/conda-build.yaml
@@ -10,7 +10,7 @@ jobs:
   macos:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: [3.7]
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - uses: conda-incubator/setup-miniconda@v2
       with:


### PR DESCRIPTION
Problem: the conda package build number is always 0.
Solution: this PR fixes this issues by fetching all the commits in the checkout stage.